### PR TITLE
31 add react router

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5794,6 +5794,19 @@
       "resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
       "integrity": "sha1-TAb8y0YC/iYCs8k9+C1+fb8aio4="
     },
+    "history": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
+      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "loose-envify": "^1.2.0",
+        "resolve-pathname": "^3.0.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0",
+        "value-equal": "^1.0.1"
+      }
+    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -5802,6 +5815,14 @@
         "hash.js": "^1.0.3",
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "hoist-non-react-statics": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
+      "integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
+      "requires": {
+        "react-is": "^16.7.0"
       }
     },
     "hosted-git-info": {
@@ -8348,6 +8369,16 @@
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha1-ftLCzMyvhNP/y3pptXcR/CCDQBs="
     },
+    "mini-create-react-context": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.3.2.tgz",
+      "integrity": "sha512-2v+OeetEyliMt5VHMXsBhABoJ0/M4RCe7fatd/fBy6SMiKazUSEt3gxxypfnk2SHMkdBYvorHRoQxuGoiwbzAw==",
+      "requires": {
+        "@babel/runtime": "^7.4.0",
+        "gud": "^1.0.0",
+        "tiny-warning": "^1.0.2"
+      }
+    },
     "mini-css-extract-plugin": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.8.0.tgz",
@@ -10738,6 +10769,52 @@
         "warning": "^4.0.2"
       }
     },
+    "react-router": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.1.2.tgz",
+      "integrity": "sha512-yjEuMFy1ONK246B+rsa0cUam5OeAQ8pyclRDgpxuSCrAlJ1qN9uZ5IgyKC7gQg0w8OM50NXHEegPh/ks9YuR2A==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "history": "^4.9.0",
+        "hoist-non-react-statics": "^3.1.0",
+        "loose-envify": "^1.3.1",
+        "mini-create-react-context": "^0.3.0",
+        "path-to-regexp": "^1.7.0",
+        "prop-types": "^15.6.2",
+        "react-is": "^16.6.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "path-to-regexp": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+          "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        }
+      }
+    },
+    "react-router-dom": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.1.2.tgz",
+      "integrity": "sha512-7BPHAaIwWpZS074UKaw1FjVdZBSVWEk8IuDXdB+OkLb8vd/WRQIpA4ag9WQk61aEfQs47wHyjWUoUGGZxpQXew==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "history": "^4.9.0",
+        "loose-envify": "^1.3.1",
+        "prop-types": "^15.6.2",
+        "react-router": "5.1.2",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
+      }
+    },
     "react-scripts": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-3.1.2.tgz",
@@ -11195,6 +11272,11 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
       "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
+    },
+    "resolve-pathname": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
+      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng=="
     },
     "resolve-url": {
       "version": "0.2.1",
@@ -12472,6 +12554,16 @@
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q="
     },
+    "tiny-invariant": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.0.6.tgz",
+      "integrity": "sha512-FOyLWWVjG+aC0UqG76V53yAWdXfH8bO6FNmyZOuUrzDzK8DI3/JRY25UD7+g49JWM1LXwymsKERB+DzI0dTEQA=="
+    },
+    "tiny-warning": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
+      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
+    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -12872,6 +12964,11 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "value-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
+      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
     },
     "vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "react": "^16.9.0",
     "react-dom": "^16.9.0",
     "react-moment": "^0.9.6",
+    "react-router-dom": "^5.1.2",
     "react-scripts": "3.1.2",
     "semantic-ui-css": "^2.4.1",
     "semantic-ui-react": "^0.88.1"

--- a/src/App.js
+++ b/src/App.js
@@ -1,34 +1,33 @@
 import React, { Component } from 'react';
 import { Container, Header } from 'semantic-ui-react';
+import { BrowserRouter as Router } from 'react-router-dom';
 
-// Components
-import UserInput from './components/UserInput';
-import DisplayResponse from './components/DisplayResponse';
-import RecentTickets from './components/RecentTickets';
+// Routes
+import Routes from './routes/Routes';
+
+const Layout = ({ children }) => (
+  <Container textAlign="center" style={{ marginTop: '3rem' }}>
+    <Header as="h1">Vigilante Web Heist</Header>
+    {children}
+  </Container>
+);
 
 class App extends Component {
   state = {
-    responseData: null,
-    ticket: {},
+    curTicket: {},
   };
 
-  setResponseData = dataFromResponse => {
-    this.setState({ responseData: dataFromResponse });
+  setCurTicket = ticket => {
+    this.setState({ curTicket: ticket });
   };
 
   render() {
     return (
-      <Container textAlign="center" style={{ marginTop: '3rem' }}>
-        <Header as="h1">Vigilante Web Heist</Header>
-
-        <UserInput response={this.setResponseData} />
-
-        <RecentTickets />
-
-        {this.state && this.state.responseData && (
-          <DisplayResponse response={this.state.responseData} />
-        )}
-      </Container>
+      <Router>
+        <Layout>
+          <Routes appState={this.state} setCurTicket={this.setCurTicket} />
+        </Layout>
+      </Router>
     );
   }
 }

--- a/src/App.js
+++ b/src/App.js
@@ -1,16 +1,11 @@
 import React, { Component } from 'react';
-import { Container, Header } from 'semantic-ui-react';
 import { BrowserRouter as Router } from 'react-router-dom';
 
 // Routes
 import Routes from './routes/Routes';
 
-const Layout = ({ children }) => (
-  <Container textAlign="center" style={{ marginTop: '3rem' }}>
-    <Header as="h1">Vigilante Web Heist</Header>
-    {children}
-  </Container>
-);
+// Components
+import Layout from './components/Layout';
 
 class App extends Component {
   state = {

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Container, Header } from 'semantic-ui-react';
+import { Link } from 'react-router-dom';
+
+const Nav = () => (
+  <div style={{ marginBottom: '2rem' }}>
+    <Header as={Link} to="/" color="blue" style={{ fontSize: '2rem' }}>
+      Vigilante Web Heist
+    </Header>
+  </div>
+);
+
+const Layout = ({ children }) => (
+  <Container textAlign="center" style={{ marginTop: '3rem' }}>
+    <Nav />
+    {children}
+  </Container>
+);
+
+export default Layout;

--- a/src/components/RecentTickets.js
+++ b/src/components/RecentTickets.js
@@ -45,7 +45,7 @@ export default class RecentTickets extends Component {
                     </td>
                     <td>{ticket.processed ? 'Yes' : 'No'}</td>
                     <td>
-                      <a href={`/ticket/${ticket.ID}`}>Ticket #{ticket.ID}</a>
+                      <a href={`/tickets/${ticket.ID}`}>Ticket #{ticket.ID}</a>
                     </td>
                   </tr>
                 ))}

--- a/src/components/RecentTickets.js
+++ b/src/components/RecentTickets.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import Moment from 'react-moment';
+import { Link } from 'react-router-dom';
 
 const recentTickets = {
   display: 'inline-block',
@@ -45,7 +46,9 @@ export default class RecentTickets extends Component {
                     </td>
                     <td>{ticket.processed ? 'Yes' : 'No'}</td>
                     <td>
-                      <a href={`/tickets/${ticket.ID}`}>Ticket #{ticket.ID}</a>
+                      <Link to={`/tickets/${ticket.ID}`}>
+                        Ticket #{ticket.ID}
+                      </Link>
                     </td>
                   </tr>
                 ))}

--- a/src/components/UserInput.js
+++ b/src/components/UserInput.js
@@ -43,7 +43,7 @@ export default class UserInput extends Component {
       const response = await res.json();
       console.log(res);
       console.log(JSON.stringify(response));
-      this.props.response(JSON.stringify(response));
+      this.props.response(response.ticket);
     } catch (error) {
       console.log(error);
     }

--- a/src/routes/NestedTicketRoutes.js
+++ b/src/routes/NestedTicketRoutes.js
@@ -1,6 +1,6 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { Header } from 'semantic-ui-react';
-import { BrowserRouter as Switch, Route } from 'react-router-dom';
+import { Switch, Route } from 'react-router-dom';
 
 // Components
 import RecentTickets from '../components/RecentTickets';
@@ -8,14 +8,14 @@ import RecentTickets from '../components/RecentTickets';
 // View sub-components
 import Ticket from '../views/Tickets/Ticket';
 
-const NestedTicketRoutes = ({ path }) => (
+const NestedTicketRoutes = ({ path, ticket }) => (
   <Switch>
     <Route exact path={path}>
       <Header as="h5">Please select a ticket.</Header>
       <RecentTickets />
     </Route>
     <Route path={`${path}/:ticketID`}>
-      <Ticket />
+      <Ticket ticket={ticket} />
     </Route>
   </Switch>
 );

--- a/src/routes/NestedTicketRoutes.js
+++ b/src/routes/NestedTicketRoutes.js
@@ -1,0 +1,23 @@
+import React, { Component } from 'react';
+import { Header } from 'semantic-ui-react';
+import { BrowserRouter as Switch, Route } from 'react-router-dom';
+
+// Components
+import RecentTickets from '../components/RecentTickets';
+
+// View sub-components
+import Ticket from '../views/Tickets/Ticket';
+
+const NestedTicketRoutes = ({ path }) => (
+  <Switch>
+    <Route exact path={path}>
+      <Header as="h5">Please select a ticket.</Header>
+      <RecentTickets />
+    </Route>
+    <Route path={`${path}/:ticketID`}>
+      <Ticket />
+    </Route>
+  </Switch>
+);
+
+export default NestedTicketRoutes;

--- a/src/routes/Routes.js
+++ b/src/routes/Routes.js
@@ -1,0 +1,18 @@
+import React, { Component } from 'react';
+import { BrowserRouter as Switch, Route } from 'react-router-dom';
+
+// Views
+import Home from '../views/Home/Home';
+import Tickets from '../views/Tickets/Tickets';
+
+const Routes = ({ appState, setCurTicket }) => (
+  <Switch>
+    <Route exact path="/" render={() => <Home setCurTicket={setCurTicket} />} />
+    <Route
+      path="/tickets"
+      render={() => <Tickets ticket={appState.curTicket} />}
+    />
+  </Switch>
+);
+
+export default Routes;

--- a/src/routes/Routes.js
+++ b/src/routes/Routes.js
@@ -1,5 +1,5 @@
-import React, { Component } from 'react';
-import { BrowserRouter as Switch, Route } from 'react-router-dom';
+import React from 'react';
+import { Switch, Route } from 'react-router-dom';
 
 // Views
 import Home from '../views/Home/Home';

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -1,0 +1,10 @@
+export const fetchTicket = async ticketID => {
+  try {
+    const res = await fetch(`/api/tickets/${ticketID}`, {
+      method: 'GET',
+    });
+    return await res.json();
+  } catch (error) {
+    console.error(error);
+  }
+};

--- a/src/views/Home/Home.js
+++ b/src/views/Home/Home.js
@@ -1,0 +1,20 @@
+import React, { Component } from 'react';
+
+// Components
+import UserInput from '../../components/UserInput';
+import RecentTickets from '../../components/RecentTickets';
+
+class Home extends Component {
+  render() {
+    const { setCurTicket } = this.props;
+    return (
+      <>
+        <UserInput response={setCurTicket} />
+
+        <RecentTickets />
+      </>
+    );
+  }
+}
+
+export default Home;

--- a/src/views/Tickets/Ticket.js
+++ b/src/views/Tickets/Ticket.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { Header } from 'semantic-ui-react';
 import { useParams } from 'react-router-dom';
 
@@ -6,7 +6,7 @@ const Ticket = () => {
   const { ticketID } = useParams();
   return (
     <>
-      <Header as="h3">{ticketID}</Header>
+      <Header as="h3">Ticket: {ticketID}</Header>
     </>
   );
 };

--- a/src/views/Tickets/Ticket.js
+++ b/src/views/Tickets/Ticket.js
@@ -1,0 +1,14 @@
+import React, { Component } from 'react';
+import { Header } from 'semantic-ui-react';
+import { useParams } from 'react-router-dom';
+
+const Ticket = () => {
+  const { ticketID } = useParams();
+  return (
+    <>
+      <Header as="h3">{ticketID}</Header>
+    </>
+  );
+};
+
+export default Ticket;

--- a/src/views/Tickets/Tickets.js
+++ b/src/views/Tickets/Tickets.js
@@ -5,13 +5,11 @@ import { useRouteMatch } from 'react-router-dom';
 // Routes
 import NestedTicketRoutes from '../../routes/NestedTicketRoutes';
 
-const Tickets = () => {
+const Tickets = ({ ticket }) => {
   const { path, url } = useRouteMatch();
   return (
     <>
-      <Header as="h3">Tickets</Header>
-
-      <NestedTicketRoutes path={path} />
+      <NestedTicketRoutes path={path} ticket={ticket} />
     </>
   );
 };

--- a/src/views/Tickets/Tickets.js
+++ b/src/views/Tickets/Tickets.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Header } from 'semantic-ui-react';
+import { useRouteMatch } from 'react-router-dom';
+
+// Routes
+import NestedTicketRoutes from '../../routes/NestedTicketRoutes';
+
+const Tickets = () => {
+  const { path, url } = useRouteMatch();
+  return (
+    <>
+      <Header as="h3">Tickets</Header>
+
+      <NestedTicketRoutes path={path} />
+    </>
+  );
+};
+
+export default Tickets;


### PR DESCRIPTION
Fixes #31. 

Touched a lot of files here, so feel free to make comments if there are issues you see, or unnecessary changes I made

## Changes made

- Added React Router to project, and made a new directory for `views`, to handle page components and components that are found solely within that page.
- Left shared components in the `components` directory.  
- Supported routes for `/` homepage, `/tickets` where it simply lists recent tickets and suggest selecting a ticket, and `/tickets/{id}` to show fields associated with a specific ticket
- Changed page header (the "Vigilante Web Heist" header) into a header link to go back home (`/`)
- Got ahead of this PR and created a helper function in `utils/api.js` for fetching a ticket by ID. I am thinking we can abstract api calls and keep their logic in here

## Other notes

- Slightly refactored the app level state to contain a `curTicket`, and the response in the `UserInput` to set that ticket. I am planning on refactoring this to take away the `curTicket` from the app level state, and instead simply redirect the user to the new ticket's route after submitting inside `UserInput`. The `Ticket` component that handles this route will always load its ticket's resources after mounting, similar to how the `RecentTickets` component fetches data from the backend. This fixes issues that would arise when navigating to a specific ticket and not having that ticket's data in the app level state
