### PR TITLE
feat(ticket, screenshot): refactor, auto refresh, stop infinite loop

### DIFF
--- a/src/routes/NestedTicketRoutes.js
+++ b/src/routes/NestedTicketRoutes.js
@@ -14,9 +14,7 @@ const NestedTicketRoutes = ({ path }) => (
       <Header as="h5">Please select a ticket.</Header>
       <RecentTickets />
     </Route>
-    <Route path={`${path}/:ticketID`}>
-      <Ticket />
-    </Route>
+    <Route path={`${path}/:ticketID`} component={Ticket} />
   </Switch>
 );
 

--- a/src/views/tickets/Screenshot.js
+++ b/src/views/tickets/Screenshot.js
@@ -3,21 +3,22 @@ import { Header, Image, Segment } from 'semantic-ui-react';
 
 export default class Screenshot extends Component {
   render() {
+    const { ticketID, processed } = this.props.ticketInfo;
     return (
       <div>
         <Segment inverted>
           <Header as="h3" inverted color="blue">
             {' '}
-            Screenshot for ticket #{this.props.ticketID}{' '}
+            Screenshot for ticket #{ticketID}{' '}
           </Header>
-          {this.props.processed && (
+          {processed && (
             <Image
               alt="fullpage screenshot"
-              src={`http://localhost:8080/api/tickets/${this.props.ticketID}/artifacts/screenshotFull.png`}
+              src={`http://localhost:8080/api/tickets/${ticketID}/artifacts/screenshotFull.png`}
               fluid
             />
           )}
-          {!this.props.processed && (
+          {!processed && (
             <Header as="h3" inverted color="blue">
               {' '}
               This ticket has not been processed. Please wait.{' '}

--- a/src/views/tickets/Screenshot.js
+++ b/src/views/tickets/Screenshot.js
@@ -2,67 +2,22 @@ import React, { Component } from 'react';
 import { Header, Image, Segment } from 'semantic-ui-react';
 
 export default class Screenshot extends Component {
-  state = {
-    id: '',
-    processed: '',
-  };
-
-  onResponseReceived = async e => {
-    this.state.id = this.props.ticketID;
-    //there is not reason why this should be called twice but
-    //I can't figure out how to pass the processed flag through the routes
-    try {
-      const res = await fetch(
-        'http://localhost:8080/api/tickets/' + this.state.id,
-        {
-          method: 'GET',
-        }
-      );
-
-      const response = await res.json();
-      var processed = response.ticket.processed;
-    } catch (error) {
-      console.log(error);
-    }
-
-    if (processed) {
-      this.setState({ processed: true });
-      const endpoint =
-        'http://localhost:8080/api/tickets/' + this.state.id + '/artifacts';
-      try {
-        const res = await fetch(endpoint, {
-          method: 'GET',
-        });
-      } catch (error) {
-        console.log(error);
-      }
-    } else {
-      this.setState({ processed: false });
-    }
-  };
-
   render() {
-    this.onResponseReceived();
-
     return (
       <div>
         <Segment inverted>
           <Header as="h3" inverted color="blue">
             {' '}
-            Screenshot for ticket #{this.state.id}{' '}
+            Screenshot for ticket #{this.props.ticketID}{' '}
           </Header>
-          {this.state.processed && (
+          {this.props.processed && (
             <Image
               alt="fullpage screenshot"
-              src={
-                'http://localhost:8080/api/tickets/' +
-                this.state.id +
-                '/artifacts/screenshotFull.png'
-              }
+              src={`http://localhost:8080/api/tickets/${this.props.ticketID}/artifacts/screenshotFull.png`}
               fluid
             />
           )}
-          {!this.state.processed && (
+          {!this.props.processed && (
             <Header as="h3" inverted color="blue">
               {' '}
               This ticket has not been processed. Please wait.{' '}

--- a/src/views/tickets/Ticket.js
+++ b/src/views/tickets/Ticket.js
@@ -8,9 +8,10 @@ export default class Ticket extends Component {
     super(props);
 
     this.state = {
-      processed: false,
-      ticketID: props.match.params.ticketID,
-      url: props.match.url,
+      ticketInfo: {
+        ticketID: props.match.params.ticketID,
+        processed: false,
+      },
       refreshInterval: setInterval(this.refreshTicketState, REFRESH_EVERY_MS),
     };
 
@@ -27,15 +28,19 @@ export default class Ticket extends Component {
   }
 
   refreshTicketState = async e => {
-    const ticketURL = `http://localhost:8080/api/tickets/${this.state.ticketID}`;
+    const ticketURL = `http://localhost:8080/api/tickets/${this.state.ticketInfo.ticketID}`;
 
     try {
       fetch(ticketURL, { method: 'GET' })
         .then(res => res.json())
         .then(res => {
-          const processed = res.ticket.processed;
+          const { processed } = res.ticket;
 
-          this.setState({ processed });
+          this.setState(prevState => {
+            const { ticketInfo } = prevState;
+            ticketInfo.processed = processed;
+            return ticketInfo;
+          });
 
           if (processed) {
             this.stopAutomaticRefreshing();
@@ -47,13 +52,10 @@ export default class Ticket extends Component {
   };
 
   render() {
+    const { ticketInfo } = this.state;
     return (
       <>
-        <Screenshot
-          ticketID={this.state.ticketID}
-          url={this.state.url}
-          processed={this.state.processed}
-        />
+        <Screenshot ticketInfo={ticketInfo} />
       </>
     );
   }

--- a/src/views/tickets/Ticket.js
+++ b/src/views/tickets/Ticket.js
@@ -1,16 +1,60 @@
-import React from 'react';
-import { Header } from 'semantic-ui-react';
-import { useParams } from 'react-router-dom';
-
+import React, { Component } from 'react';
 import Screenshot from './Screenshot';
 
-const Ticket = () => {
-  const { ticketID, url } = useParams();
-  return (
-    <>
-      <Screenshot ticketID={ticketID} url={url} />
-    </>
-  );
-};
+const REFRESH_EVERY_MS = 1000;
 
-export default Ticket;
+export default class Ticket extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      processed: false,
+      ticketID: props.match.params.ticketID,
+      url: props.match.url,
+      refreshInterval: setInterval(this.refreshTicketState, REFRESH_EVERY_MS),
+    };
+
+    this.refreshTicketState();
+  }
+
+  stopAutomaticRefreshing() {
+    clearInterval(this.state.refreshInterval);
+  }
+
+  componentWillUnmount() {
+    // clean up in case we're navigating away:
+    this.stopAutomaticRefreshing();
+  }
+
+  refreshTicketState = async e => {
+    const ticketURL = `http://localhost:8080/api/tickets/${this.state.ticketID}`;
+
+    try {
+      fetch(ticketURL, { method: 'GET' })
+        .then(res => res.json())
+        .then(res => {
+          const processed = res.ticket.processed;
+
+          this.setState({ processed });
+
+          if (processed) {
+            this.stopAutomaticRefreshing();
+          }
+        });
+    } catch (error) {
+      console.log(error);
+    }
+  };
+
+  render() {
+    return (
+      <>
+        <Screenshot
+          ticketID={this.state.ticketID}
+          url={this.state.url}
+          processed={this.state.processed}
+        />
+      </>
+    );
+  }
+}


### PR DESCRIPTION
BROTHER I REQUIE LöÖÖÖÖPS


![](https://i.kym-cdn.com/photos/images/newsfeed/001/393/650/27f.jpg)

- Moves the refreshing of the `processed` variable to the `Ticket` class, allowing it to pass down results to descendant objects
- Fixes an infinite loop caused by call constantly being made
- Removes unused calls to /artifacts endpoint
- Uses react router features to pass through params, instead of `useParams()`
- Removed most functionality from `Screenshot`, instead updating its props when new data is available