### PR TITLE
refactor(api): common client for all API usage

### DIFF
--- a/src/components/RecentTickets.js
+++ b/src/components/RecentTickets.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import Moment from 'react-moment';
 import { Link } from 'react-router-dom';
+import { getTicketListing } from '../utils/api.js';
 
 const recentTickets = {
   display: 'inline-block',
@@ -27,59 +28,67 @@ export default class RecentTickets extends Component {
 
         {this.state.lastResponse ? (
           <div>
-            <h3>Recent Tickets:</h3>
-            <table className="ui celled padded table">
-              <thead>
-                <tr>
-                  <th>URL</th>
-                  <th>Submitted</th>
-                  <th>Processed</th>
-                  <th>Output</th>
-                </tr>
-              </thead>
-              <tbody>
-                {this.state.lastResponse.map(ticket => (
-                  <tr key={ticket.ID}>
-                    <td>{ticket.url}</td>
-                    <td>
-                      <Moment date={ticket.CreatedAt} fromNow />
-                    </td>
-                    <td>{ticket.processed ? 'Yes' : 'No'}</td>
-                    <td>
-                      <Link to={`/tickets/${ticket.ID}`}>
-                        Ticket #{ticket.ID}
-                      </Link>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-              <tfoot>
-                <tr>
-                  <th colSpan="5">
-                    <div className="ui right floated pagination menu">
-                      <a className="icon item" href={'/#'}>
-                        <i className="left chevron icon"></i>
-                      </a>
-                      <a className="item" href={'/#page1'}>
-                        1
-                      </a>
-                      <a className="item" href={'/#page2'}>
-                        2
-                      </a>
-                      <a className="item" href={'/#page3'}>
-                        3
-                      </a>
-                      <a className="item" href={'/#page4'}>
-                        4
-                      </a>
-                      <a className="icon item" href={'/#page2'}>
-                        <i className="right chevron icon"></i>
-                      </a>
-                    </div>
-                  </th>
-                </tr>
-              </tfoot>
-            </table>
+            {this.state.lastResponse.length > 0 ? (
+              <div>
+                <h3>Recent Tickets:</h3>
+                <table className="ui celled padded table">
+                  <thead>
+                    <tr>
+                      <th>URL</th>
+                      <th>Submitted</th>
+                      <th>Processed</th>
+                      <th>Output</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {this.state.lastResponse.map(ticket => (
+                      <tr key={ticket.ID}>
+                        <td>{ticket.url}</td>
+                        <td>
+                          <Moment date={ticket.CreatedAt} fromNow />
+                        </td>
+                        <td>{ticket.processed ? 'Yes' : 'No'}</td>
+                        <td>
+                          <Link to={`/tickets/${ticket.ID}`}>
+                            Ticket #{ticket.ID}
+                          </Link>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                  <tfoot>
+                    <tr>
+                      <th colSpan="5">
+                        <div className="ui right floated pagination menu">
+                          <a className="icon item" href={'/#'}>
+                            <i className="left chevron icon"></i>
+                          </a>
+                          <a className="item" href={'/#page1'}>
+                            1
+                          </a>
+                          <a className="item" href={'/#page2'}>
+                            2
+                          </a>
+                          <a className="item" href={'/#page3'}>
+                            3
+                          </a>
+                          <a className="item" href={'/#page4'}>
+                            4
+                          </a>
+                          <a className="icon item" href={'/#page2'}>
+                            <i className="right chevron icon"></i>
+                          </a>
+                        </div>
+                      </th>
+                    </tr>
+                  </tfoot>
+                </table>
+              </div>
+            ) : (
+              <div>
+                <i>(No Recent Tickets)</i>
+              </div>
+            )}
           </div>
         ) : null}
       </div>
@@ -92,27 +101,15 @@ export default class RecentTickets extends Component {
 
   async refresh() {
     try {
-      // console.log('Requesting listing of recent tickets from server...');
+      const tickets = await getTicketListing();
 
-      const ticketsResponse = await fetch(
-        'http://localhost:8080/api/tickets'
-      ).then(res => res.json());
-
-      // console.log('Received ticket listing response from server:');
-      // console.log(ticketsResponse);
-
-      if (ticketsResponse.success) {
-        this.setState({
-          lastError: null,
-          lastResponse: ticketsResponse.tickets,
-        });
-      } else {
-        throw new Error(`Server returned error: ${ticketsResponse.message}`);
-      }
+      this.setState({
+        lastError: null,
+        lastResponse: tickets.tickets,
+      });
     } catch (error) {
       this.setState({ lastError: error.message, lastResponse: null });
 
-      console.log('Failed to load recent tickets:');
       console.log(error);
     }
   }

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -1,4 +1,4 @@
-const API_STUB = process.env.API_STUP || 'http://localhost:8080/api';
+const API_STUB = process.env.API_STUB || 'http://localhost:8080/api';
 
 const throwIfNot200 = res => {
   if (res.status >= 200 && res.status < 300) {

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -1,37 +1,74 @@
-export const fetchTicket = async ticketID => {
-  try {
-    const res = await fetch(`http://localhost:8080/api/tickets/${ticketID}`);
-    // handle bad error codes
-    if (res.status !== 200) {
-      console.error(res);
-      return null;
-    }
-    // we made it this far, good to return json
-    return await res.json();
-  } catch (error) {
-    // handle error
-    console.error(error);
-    return null;
+const API_STUB = 'http://localhost:8080/api';
+
+const throwIfNot200 = res => {
+  if (res.status >= 200 && res.status < 300) {
+    return Promise.resolve(res);
+  }
+
+  return Promise.reject(new Error(res.statusText));
+};
+
+const throwIfRepsonseNotSuccessful = res => {
+  if (!res.success) {
+    return Promise.reject(new Error(res.message));
+  } else {
+    return Promise.resolve(res);
   }
 };
 
-export const createTicket = async body => {
-  try {
-    // fetch from backend
-    const res = await fetch('http://localhost:8080/api/tickets', {
-      method: 'POST',
-      body,
-    });
-    // handle bad error codes
-    if (res.status !== 200) {
-      console.error(res);
-      return null;
-    }
-    // we made it this far, good to return json
-    return await res.json();
-  } catch (error) {
-    // handle error
-    console.error(error);
-    return null;
-  }
+const convertToJSON = res => res.json();
+
+const convertToText = res => res.text();
+
+const logOnFailure = err => {
+  console.error('Failure when communicating with API:');
+  console.error(err);
+
+  // throw so upstream can catch if they want to:
+  throw err;
+};
+
+export const getTicketListing = () => {
+  return fetch(`${API_STUB}/tickets`)
+    .then(throwIfNot200)
+    .then(convertToJSON)
+    .then(throwIfRepsonseNotSuccessful)
+    .catch(logOnFailure);
+};
+
+export const getTicket = ticketID => {
+  return fetch(`${API_STUB}/tickets/${ticketID}`)
+    .then(throwIfNot200)
+    .then(convertToJSON)
+    .then(throwIfRepsonseNotSuccessful)
+    .catch(logOnFailure);
+};
+
+export const createTicket = body => {
+  return fetch(`${API_STUB}/tickets`, {
+    method: 'POST',
+    body,
+  })
+    .then(throwIfNot200)
+    .then(convertToJSON)
+    .then(throwIfRepsonseNotSuccessful)
+    .catch(logOnFailure);
+};
+
+export const getArtifactURL = (ticketId, filename) =>
+  `${API_STUB}/tickets/${ticketId}/artifacts/${filename}`;
+
+export const getArtifactListing = ticketId => {
+  return fetch(`${API_STUB}/tickets/${ticketId}/artifacts`)
+    .then(throwIfNot200)
+    .then(convertToJSON)
+    .then(throwIfRepsonseNotSuccessful)
+    .catch(logOnFailure);
+};
+
+export const getArtifact = (ticketId, filename) => {
+  return fetch(getArtifactURL(ticketId, filename))
+    .then(throwIfNot200)
+    .then(convertToText)
+    .catch(logOnFailure);
 };

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -1,4 +1,4 @@
-const API_STUB = 'http://localhost:8080/api';
+const API_STUB = process.env.API_STUP || 'http://localhost:8080/api';
 
 const throwIfNot200 = res => {
   if (res.status >= 200 && res.status < 300) {

--- a/src/views/home/UserInput.js
+++ b/src/views/home/UserInput.js
@@ -39,13 +39,13 @@ export default class UserInput extends Component {
   onFormSubmit = async e => {
     e.preventDefault();
     const body = JSON.stringify(this.state);
-    const res = await createTicket(body);
-    if (!res) {
-      console.error('Error creating ticket!!');
-      // TODO: let user know about error
-    } else {
-      console.log(res);
+
+    try {
+      const res = await createTicket(body);
+
       this.setState({ newTicket: res.ticket });
+    } catch (error) {
+      // TODO: let user know about the error
     }
   };
   render() {

--- a/src/views/tickets/Screenshot.js
+++ b/src/views/tickets/Screenshot.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import { Image, Segment } from 'semantic-ui-react';
+import { getArtifactURL } from '../../utils/api.js';
 
 export default class Screenshot extends Component {
   render() {
@@ -7,11 +8,7 @@ export default class Screenshot extends Component {
       <Segment inverted>
         <Image
           alt="fullpage screenshot"
-          src={
-            'http://localhost:8080/api/tickets/' +
-            this.props.ticketID +
-            '/artifacts/screenshotFull.png'
-          }
+          src={getArtifactURL(this.props.ticketID, 'screenshotFull.png')}
           fluid
         />
       </Segment>

--- a/src/views/tickets/Ticket.js
+++ b/src/views/tickets/Ticket.js
@@ -3,6 +3,7 @@ import { Loader, Placeholder, Segment } from 'semantic-ui-react';
 
 import Screenshot from './Screenshot';
 import JSViewer from './JSViewer';
+import { getTicket } from '../../utils/api.js';
 
 const REFRESH_EVERY_MS = 1000;
 
@@ -36,26 +37,19 @@ export default class Ticket extends Component {
   }
 
   refreshTicketState = async e => {
-    const ticketURL = `http://localhost:8080/api/tickets/${this.state.ticketInfo.ticketID}`;
+    const ticketId = this.state.ticketInfo.ticketID;
 
     try {
-      fetch(ticketURL, { method: 'GET' })
-        .then(res => res.json())
-        .then(res => {
-          const { processed } = res.ticket;
+      const ticket = await getTicket(ticketId);
+      const { processed } = ticket.ticket;
 
-          this.setState(prevState => {
-            const { ticketInfo } = prevState;
-            ticketInfo.processed = processed;
-            return ticketInfo;
-          });
+      this.setState({ ticketInfo: { ...this.state.ticketInfo, processed } });
 
-          if (processed) {
-            this.stopAutomaticRefreshing();
-          }
-        });
+      if (processed) {
+        this.stopAutomaticRefreshing();
+      }
     } catch (error) {
-      console.log(error);
+      // todo: display the error on the page
     }
   };
 
@@ -73,6 +67,7 @@ export default class Ticket extends Component {
               active
               inline
               content="The ticket is being processed. Please wait."
+              style={{ marginBottom: '50px' }}
             />
             <Segment inverted>
               <Placeholder fluid inverted>


### PR DESCRIPTION
Resolves #50. Extends the API interface to cover all endpoints used by the frontend, and replaces all direct usages of endpoints (via `fetch`, etc) in the code with a call to the client. Also replaces the ticket listing view with _(No Recent TIckets_ if no jobs have yet been submitted.

Note there's many usages of the API that swallow errors without surfacing them to the user. They'll still appear on the console. I've marked these with TODO entries to come back to later.