### PR TITLE
fix(#49): show error when navigating to non-existing ticket url

### DIFF
--- a/src/views/tickets/Ticket.js
+++ b/src/views/tickets/Ticket.js
@@ -65,7 +65,7 @@ export default class Ticket extends Component {
 
   render() {
     const { ticketInfo } = this.state;
-    if (this.state.hasError != '') {
+    if (this.state.hasError !== '') {
       return (
         <TicketNotFound
           ticketID={ticketInfo.ticketID}

--- a/src/views/tickets/Ticket.js
+++ b/src/views/tickets/Ticket.js
@@ -18,7 +18,7 @@ export default class Ticket extends Component {
         processed: false,
       },
       currentCode: '',
-      hasError: false,
+      hasError: '',
     };
 
     this.refreshInterval = setInterval(
@@ -51,8 +51,7 @@ export default class Ticket extends Component {
         this.stopAutomaticRefreshing();
       }
     } catch (error) {
-      // todo: display the error on the page
-      this.setState({ hasError: true });
+      this.setState({ hasError: error.message });
     }
   };
 
@@ -61,13 +60,18 @@ export default class Ticket extends Component {
   };
 
   static getDerivedStateFromError = error => {
-    this.setState({ hasError: true });
+    this.setState({ hasError: error.message });
   };
 
   render() {
     const { ticketInfo } = this.state;
-    if (this.state.hasError) {
-      return <TicketNotFound ticketID={ticketInfo.ticketID} errCode={404} />;
+    if (this.state.hasError != '') {
+      return (
+        <TicketNotFound
+          ticketID={ticketInfo.ticketID}
+          errMessage={this.state.hasError}
+        />
+      );
     } else {
       return (
         <>

--- a/src/views/tickets/Ticket.js
+++ b/src/views/tickets/Ticket.js
@@ -4,6 +4,7 @@ import { Loader, Placeholder, Segment } from 'semantic-ui-react';
 import Screenshot from './Screenshot';
 import JSViewer from './JSViewer';
 import { getTicket } from '../../utils/api.js';
+import TicketNotFound from './TicketNotFound';
 
 const REFRESH_EVERY_MS = 1000;
 
@@ -17,6 +18,7 @@ export default class Ticket extends Component {
         processed: false,
       },
       currentCode: '',
+      hasError: false,
     };
 
     this.refreshInterval = setInterval(
@@ -50,6 +52,7 @@ export default class Ticket extends Component {
       }
     } catch (error) {
       // todo: display the error on the page
+      this.setState({ hasError: true });
     }
   };
 
@@ -57,44 +60,52 @@ export default class Ticket extends Component {
     this.setState({ currentCode: data.value });
   };
 
+  static getDerivedStateFromError = error => {
+    this.setState({ hasError: true });
+  };
+
   render() {
     const { ticketInfo } = this.state;
-    return (
-      <>
-        {!this.state.ticketInfo.processed && (
-          <div>
-            <Loader
-              active
-              inline
-              content="The ticket is being processed. Please wait."
-              style={{ marginBottom: '50px' }}
-            />
-            <Segment inverted>
-              <Placeholder fluid inverted>
-                <Placeholder.Image />
-                <Placeholder.Paragraph>
-                  <Placeholder.Line />
-                  <Placeholder.Line />
-                  <Placeholder.Line />
-                  <Placeholder.Line />
-                  <Placeholder.Line />
-                  <Placeholder.Line />
-                </Placeholder.Paragraph>
-              </Placeholder>
-            </Segment>
-          </div>
-        )}
-        {this.state.ticketInfo.processed && (
-          <>
-            <Screenshot ticketID={ticketInfo.ticketID} />
-            <JSViewer
-              ticketID={ticketInfo.ticketID}
-              onFileSelectionChange={this.onFileSelectionChange}
-              code={this.state.currentCode}
-            />
-          </>
-        )}
-      </>
-    );
+    if (this.state.hasError) {
+      return <TicketNotFound ticketID={ticketInfo.ticketID} errCode={404} />;
+    } else {
+      return (
+        <>
+          {!this.state.ticketInfo.processed && (
+            <div>
+              <Loader
+                active
+                inline
+                content="The ticket is being processed. Please wait."
+                style={{ marginBottom: '50px' }}
+              />
+              <Segment inverted>
+                <Placeholder fluid inverted>
+                  <Placeholder.Image />
+                  <Placeholder.Paragraph>
+                    <Placeholder.Line />
+                    <Placeholder.Line />
+                    <Placeholder.Line />
+                    <Placeholder.Line />
+                    <Placeholder.Line />
+                    <Placeholder.Line />
+                  </Placeholder.Paragraph>
+                </Placeholder>
+              </Segment>
+            </div>
+          )}
+          {this.state.ticketInfo.processed && (
+            <>
+              <Screenshot ticketID={ticketInfo.ticketID} />
+              <JSViewer
+                ticketID={ticketInfo.ticketID}
+                onFileSelectionChange={this.onFileSelectionChange}
+                code={this.state.currentCode}
+              />
+            </>
+          )}
+        </>
+      );
+    }
   }
 }

--- a/src/views/tickets/TicketNotFound.js
+++ b/src/views/tickets/TicketNotFound.js
@@ -8,8 +8,8 @@ const TicketNotFound = ({ ticketID, errCode }) => {
       <h1>
         {' '}
         We're sorry! There is something wrong with ticket{' '}
-        <code>{ticketID}</code> (Error Code: <code>{errCode}</code>), please the
-        ticket exists or not.{' '}
+        <code>{ticketID}</code> (Error Code: <code>{errCode}</code>), please
+        check the ticket exists or not.{' '}
       </h1>
       <Link to="/">Return to Homepage</Link>
     </div>

--- a/src/views/tickets/TicketNotFound.js
+++ b/src/views/tickets/TicketNotFound.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+// TODO: Should we add the error code?
+const TicketNotFound = ({ ticketID, errCode }) => {
+  return (
+    <div>
+      <h1>
+        {' '}
+        We're sorry! There is something wrong with ticket{' '}
+        <code>{ticketID}</code> (Error Code: <code>{errCode}</code>), please the
+        ticket exists or not.{' '}
+      </h1>
+      <Link to="/">Return to Homepage</Link>
+    </div>
+  );
+};
+
+export default TicketNotFound;

--- a/src/views/tickets/TicketNotFound.js
+++ b/src/views/tickets/TicketNotFound.js
@@ -2,14 +2,14 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 
 // TODO: Should we add the error code?
-const TicketNotFound = ({ ticketID, errCode }) => {
+const TicketNotFound = ({ ticketID, errMessage }) => {
   return (
     <div>
       <h1>
         {' '}
         We're sorry! There is something wrong with ticket{' '}
-        <code>{ticketID}</code> (Error Code: <code>{errCode}</code>), please
-        check the ticket exists or not.{' '}
+        <code>{ticketID}</code> (Error: <code>{errMessage}</code>), please check
+        the ticket exists or not.{' '}
       </h1>
       <Link to="/">Return to Homepage</Link>
     </div>

--- a/src/views/tickets/TicketNotFound.js
+++ b/src/views/tickets/TicketNotFound.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 
-// TODO: Should we add the error code?
 const TicketNotFound = ({ ticketID, errMessage }) => {
   return (
     <div>


### PR DESCRIPTION
Fix #49 .
In this PR:
- Adding the page if the ticket does not exist in views/tickets/TicketNotFound.js.
- Navigating to the page if the ticket does not exist. 
<img width="1407" alt="Screen Shot 2020-02-07 at 14 26 53" src="https://user-images.githubusercontent.com/25854424/74064141-aa1b9a80-49b7-11ea-82ea-655a8fa29d96.png">


Announcements:
- Try to keep the same page format as PR #63 .
- Error handling format follows [React Error Boundaries](https://reactjs.org/blog/2017/07/26/error-handling-in-react-16.html).

Question(s):
- The error code is currently hardcoded, do we need to get them from the error messages?
- Should I follow the format that we always used?