### PR TITLE
Feat: show all screenshots in carousel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4120,10 +4120,20 @@
         "regexp.prototype.flags": "^1.2.0"
       }
     },
+    "deep-freeze": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/deep-freeze/-/deep-freeze-0.0.1.tgz",
+      "integrity": "sha1-OgsABd4YZygZ39OM0x+RF5yJPoQ="
+    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+    },
+    "deepmerge": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-2.2.1.tgz",
+      "integrity": "sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA=="
     },
     "default-gateway": {
       "version": "4.2.0",
@@ -4509,6 +4519,14 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.0.tgz",
       "integrity": "sha1-aNYITKsbB5dnVA2A5Wo5tCPkq/Q="
+    },
+    "equals": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/equals/-/equals-1.0.5.tgz",
+      "integrity": "sha1-ISBi3eXhpRDZVfE1mO/MamIbas4=",
+      "requires": {
+        "jkroso-type": "1"
+      }
     },
     "errno": {
       "version": "0.1.7",
@@ -7825,6 +7843,11 @@
         }
       }
     },
+    "jkroso-type": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/jkroso-type/-/jkroso-type-1.1.1.tgz",
+      "integrity": "sha1-vEztbWxF/gdFKCuvyGqfjE/JzmE="
+    },
     "jquery": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
@@ -10598,6 +10621,18 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew="
+    },
+    "pure-react-carousel": {
+      "version": "1.25.2",
+      "resolved": "https://registry.npmjs.org/pure-react-carousel/-/pure-react-carousel-1.25.2.tgz",
+      "integrity": "sha512-QN6Kzvbp+n2ywuCORi0TxhG17byPmr0yidJltUJ/M+4Mebf3ZlzMSOm1C78hGot3dhqyrtnRi6rLBcpAk3m3Og==",
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "deep-freeze": "0.0.1",
+        "deepmerge": "^2.2.1",
+        "equals": "^1.0.5",
+        "prop-types": "^15.6.2"
+      }
     },
     "q": {
       "version": "1.5.1",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "js-beautify": "^1.10.2",
     "moment": "^2.24.0",
     "perms": "^0.1.0",
+    "pure-react-carousel": "^1.25.2",
     "react": "^16.9.0",
     "react-ace": "^8.0.0",
     "react-dom": "^16.9.0",

--- a/src/components/CustomDotGroup.js
+++ b/src/components/CustomDotGroup.js
@@ -1,0 +1,25 @@
+import PropTypes from 'prop-types';
+import { Dot } from 'pure-react-carousel';
+import React from 'react';
+import { Button, Container } from 'semantic-ui-react';
+
+const CustomDotGroup = ({ slides, size }) => (
+  <Container textAlign="center">
+    <Button.Group size={size}>
+      {[...Array(slides).keys()].map(slide => (
+        <Button as={Dot} key={slide} icon="circle" slide={slide} />
+      ))}
+    </Button.Group>
+  </Container>
+);
+
+CustomDotGroup.defaultProps = {
+  size: 'mini',
+};
+
+CustomDotGroup.propTypes = {
+  slides: PropTypes.number.isRequired,
+  size: PropTypes.string,
+};
+
+export default CustomDotGroup;

--- a/src/views/tickets/Screenshot.js
+++ b/src/views/tickets/Screenshot.js
@@ -1,5 +1,12 @@
 import React, { Component } from 'react';
-import { Image, Segment, Grid, Divider, Container } from 'semantic-ui-react';
+import {
+  Image,
+  Segment,
+  Divider,
+  Icon,
+  Button,
+  Modal,
+} from 'semantic-ui-react';
 import { getTicket, getArtifactURL } from '../../utils/api.js';
 
 import 'pure-react-carousel/dist/react-carousel.es.css';
@@ -12,7 +19,9 @@ export default class Screenshot extends Component {
     singleScreenshot: true,
   };
   carousel = [];
+
   async getTicket() {
+    // always get full page screenshot and add it to the carousel
     let image = (
       <Slide index={0} width="100%">
         <Image
@@ -24,7 +33,7 @@ export default class Screenshot extends Component {
       </Slide>
     );
     this.carousel.push(image);
-    debugger;
+
     try {
       let ticket = await getTicket(this.props.ticketID);
       const length =
@@ -33,9 +42,9 @@ export default class Screenshot extends Component {
         this.setState({ singleScreenshot: false });
       }
       this.setState({ carouselLength: length });
+
       for (let i in ticket.ticket.screenshots) {
         const filename = ticket.ticket.screenshots[i].filename;
-        //const screenshot = ticket.screenshots[i];
         let carouselImg = (
           <Slide index={i + 1} centered>
             <Image
@@ -52,7 +61,6 @@ export default class Screenshot extends Component {
     } catch (error) {
       // todo: tell user about error
     }
-    debugger;
   }
 
   componentDidMount() {
@@ -60,6 +68,9 @@ export default class Screenshot extends Component {
   }
 
   render() {
+    //Carasoul has option to play
+    //isPlaying="true"
+    //interval="3500"
     return (
       <div>
         {this.state.singleScreenshot ? (
@@ -68,6 +79,7 @@ export default class Screenshot extends Component {
             src={getArtifactURL(this.props.ticketID, 'screenshotFull.png')}
             bordered
             centered
+            fluid
           />
         ) : (
           <Segment maxwidth={100}>
@@ -77,8 +89,28 @@ export default class Screenshot extends Component {
               totalSlides={this.state.carouselLength}
             >
               <Slider>{this.carousel}</Slider>
-
               <Divider />
+              <Modal
+                trigger={
+                  <Button floated="right" icon>
+                    {' '}
+                    <Icon name="expand" />{' '}
+                  </Button>
+                }
+              >
+                <Modal.Content image>
+                  <Image
+                    alt="fullpage screenshot"
+                    src={getArtifactURL(
+                      this.props.ticketID,
+                      'screenshotFull.png'
+                    )}
+                    bordered
+                    centered
+                    fluid
+                  />
+                </Modal.Content>
+              </Modal>
               <CustomDotGroup slides={this.state.carouselLength} />
             </CarouselProvider>
           </Segment>

--- a/src/views/tickets/Screenshot.js
+++ b/src/views/tickets/Screenshot.js
@@ -16,7 +16,6 @@ import CustomDotGroup from '../../components/CustomDotGroup.js';
 export default class Screenshot extends Component {
   state = {
     carouselLength: 1,
-    singleScreenshot: true,
   };
   carousel = [];
 
@@ -40,9 +39,6 @@ export default class Screenshot extends Component {
         carouselLength:
           this.state.carouselLength + ticket.ticket.screenshots.length,
       });
-      if (this.state.carouselLength > 1) {
-        this.setState({ singleScreenshot: false });
-      }
 
       for (let i in ticket.ticket.screenshots) {
         const filename = ticket.ticket.screenshots[i].filename;
@@ -74,7 +70,7 @@ export default class Screenshot extends Component {
     //interval="3500"
     return (
       <div>
-        {this.state.singleScreenshot ? (
+        {this.state.carouselLength === 1 ? (
           <Image
             alt="fullpage screenshot"
             src={getArtifactURL(this.props.ticketID, 'screenshotFull.png')}

--- a/src/views/tickets/Screenshot.js
+++ b/src/views/tickets/Screenshot.js
@@ -36,12 +36,13 @@ export default class Screenshot extends Component {
 
     try {
       let ticket = await getTicket(this.props.ticketID);
-      const length =
-        this.state.carouselLength + ticket.ticket.screenshots.length;
-      if (length > 1) {
+      this.setState({
+        carouselLength:
+          this.state.carouselLength + ticket.ticket.screenshots.length,
+      });
+      if (this.state.carouselLength > 1) {
         this.setState({ singleScreenshot: false });
       }
-      this.setState({ carouselLength: length });
 
       for (let i in ticket.ticket.screenshots) {
         const filename = ticket.ticket.screenshots[i].filename;

--- a/src/views/tickets/Screenshot.js
+++ b/src/views/tickets/Screenshot.js
@@ -1,21 +1,58 @@
 import React, { Component } from 'react';
-import { Image, Segment, Grid } from 'semantic-ui-react';
+import { Image, Segment, Grid, Divider, Container } from 'semantic-ui-react';
 import { getTicket, getArtifactURL } from '../../utils/api.js';
+
+import 'pure-react-carousel/dist/react-carousel.es.css';
+import { CarouselProvider, Slide, Slider } from 'pure-react-carousel';
+import CustomDotGroup from '../../components/CustomDotGroup.js';
 
 export default class Screenshot extends Component {
   state = {
-    height: 0,
-    width: 0,
+    carouselLength: 1,
+    singleScreenshot: true,
   };
+  carousel = [];
   async getTicket() {
+    let image = (
+      <Slide index={0} width="100%">
+        <Image
+          alt="fullpage screenshot"
+          src={getArtifactURL(this.props.ticketID, 'screenshotFull.png')}
+          bordered
+          centered
+        />
+      </Slide>
+    );
+    this.carousel.push(image);
+    debugger;
     try {
-      let value = await getTicket(this.props.ticketID);
+      let ticket = await getTicket(this.props.ticketID);
+      const length =
+        this.state.carouselLength + ticket.ticket.screenshots.length;
+      if (length > 1) {
+        this.setState({ singleScreenshot: false });
+      }
+      this.setState({ carouselLength: length });
+      for (let i in ticket.ticket.screenshots) {
+        const filename = ticket.ticket.screenshots[i].filename;
+        //const screenshot = ticket.screenshots[i];
+        let carouselImg = (
+          <Slide index={i + 1} centered>
+            <Image
+              alt="fullpage screenshot"
+              src={getArtifactURL(this.props.ticketID, filename)}
+              bordered
+              centered
+            />
+          </Slide>
+        );
 
-      this.setState({ height: value.ticket.screenshots[0].height });
-      this.setState({ width: value.ticket.screenshots[0].width });
+        this.carousel.push(carouselImg);
+      }
     } catch (error) {
       // todo: tell user about error
     }
+    debugger;
   }
 
   componentDidMount() {
@@ -23,31 +60,30 @@ export default class Screenshot extends Component {
   }
 
   render() {
-    let image = (
-      <Image
-        alt="fullpage screenshot"
-        src={getArtifactURL(this.props.ticketID, 'screenshotFull.png')}
-        fluid
-        bordered
-      />
-    );
-    //if there is a heigth/width apply it else the image is fluid
-    if (this.state.height !== 0 && this.state.width !== 0) {
-      image = (
-        <Image
-          alt="fullpage screenshot"
-          src={getArtifactURL(this.props.ticketID, 'screenshotFull.png')}
-          heigth={this.state.height}
-          width={this.state.width}
-          centered
-          bordered
-        />
-      );
-    }
     return (
-      <Grid columns={1} centered padded>
-        <Segment compact> {image}</Segment>
-      </Grid>
+      <div>
+        {this.state.singleScreenshot ? (
+          <Image
+            alt="fullpage screenshot"
+            src={getArtifactURL(this.props.ticketID, 'screenshotFull.png')}
+            bordered
+            centered
+          />
+        ) : (
+          <Segment maxwidth={100}>
+            <CarouselProvider
+              naturalSlideWidth={1}
+              naturalSlideHeight={0.5}
+              totalSlides={this.state.carouselLength}
+            >
+              <Slider>{this.carousel}</Slider>
+
+              <Divider />
+              <CustomDotGroup slides={this.state.carouselLength} />
+            </CarouselProvider>
+          </Segment>
+        )}
+      </div>
     );
   }
 }

--- a/src/views/tickets/Ticket.js
+++ b/src/views/tickets/Ticket.js
@@ -1,11 +1,5 @@
 import React, { Component } from 'react';
-import {
-  Loader,
-  Placeholder,
-  Segment,
-  Divider,
-  Container,
-} from 'semantic-ui-react';
+import { Loader, Placeholder, Segment, Divider } from 'semantic-ui-react';
 
 import Screenshot from './Screenshot';
 import JSViewer from './JSViewer';
@@ -108,7 +102,6 @@ export default class Ticket extends Component {
           {this.state.ticketInfo.processed && (
             <>
               <Screenshot ticketID={ticketInfo.ticketID} />
-
               <Divider hidden />
               <JSViewer
                 ticketID={ticketInfo.ticketID}

--- a/src/views/tickets/Ticket.js
+++ b/src/views/tickets/Ticket.js
@@ -1,5 +1,11 @@
 import React, { Component } from 'react';
-import { Loader, Placeholder, Segment, Divider } from 'semantic-ui-react';
+import {
+  Loader,
+  Placeholder,
+  Segment,
+  Divider,
+  Container,
+} from 'semantic-ui-react';
 
 import Screenshot from './Screenshot';
 import JSViewer from './JSViewer';
@@ -76,45 +82,42 @@ export default class Ticket extends Component {
     } else {
       return (
         <>
-        {!this.state.ticketInfo.processed && (
-          <div>
-            <Loader
-              active
-              inline
-              content="The ticket is being processed. Please wait."
-              style={{ marginBottom: '50px' }}
-            />
-            <Segment inverted>
-              <Placeholder fluid inverted>
-                <Placeholder.Image />
-                <Placeholder.Paragraph>
-                  <Placeholder.Line />
-                  <Placeholder.Line />
-                  <Placeholder.Line />
-                  <Placeholder.Line />
-                  <Placeholder.Line />
-                  <Placeholder.Line />
-                </Placeholder.Paragraph>
-              </Placeholder>
-            </Segment>
-          </div>
-        )}
-        {this.state.ticketInfo.processed && (
-          <>
-            <Screenshot
-              ticketID={ticketInfo.ticketID}
-              height={ticketInfo.height}
-              width={ticketInfo.width}
-            />
-            <Divider hidden />
-            <JSViewer
-              ticketID={ticketInfo.ticketID}
-              onFileSelectionChange={this.onFileSelectionChange}
-              code={this.state.currentCode}
-            />
-          </>
-        )}
-      </>
+          {!this.state.ticketInfo.processed && (
+            <div>
+              <Loader
+                active
+                inline
+                content="The ticket is being processed. Please wait."
+                style={{ marginBottom: '50px' }}
+              />
+              <Segment inverted>
+                <Placeholder fluid inverted>
+                  <Placeholder.Image />
+                  <Placeholder.Paragraph>
+                    <Placeholder.Line />
+                    <Placeholder.Line />
+                    <Placeholder.Line />
+                    <Placeholder.Line />
+                    <Placeholder.Line />
+                    <Placeholder.Line />
+                  </Placeholder.Paragraph>
+                </Placeholder>
+              </Segment>
+            </div>
+          )}
+          {this.state.ticketInfo.processed && (
+            <>
+              <Screenshot ticketID={ticketInfo.ticketID} />
+
+              <Divider hidden />
+              <JSViewer
+                ticketID={ticketInfo.ticketID}
+                onFileSelectionChange={this.onFileSelectionChange}
+                code={this.state.currentCode}
+              />
+            </>
+          )}
+        </>
       );
     }
   }


### PR DESCRIPTION
Fixes #71 
In this PR:

- Adds pure-react-carousel to package.-lock.json using:  ``` npm i pure-react-carousel ```

- Adds a carousel to display all screenshots if there is more than one screenshot

- Default behavior: show full page screenshot if there isn't more than one screenshot

- Adds full page screenshot button to carousel. On press the button shows the full page screenshot in a modal

Note the carousel itself fills but the part of the page that it's been allocated. This is a layout issue with the other components that needs to be discussed.